### PR TITLE
Debug Database 

### DIFF
--- a/backend/src/main/java/Group3/HealthController.java
+++ b/backend/src/main/java/Group3/HealthController.java
@@ -8,6 +8,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthController {
 
+    @GetMapping("/")
+    public Map<String, Object> root() {
+        return Map.of(
+            "status", "ok",
+            "service", "food-meal-api",
+            "health", "/health"
+        );
+    }
+
     /* How to test in PowerShell:
       cd backend
       ./gradlew bootRun to load SpringBoot

--- a/backend/src/main/java/Group3/config/CorsConfig.java
+++ b/backend/src/main/java/Group3/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package Group3;
+package Group3.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -6,21 +6,30 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 public class CorsConfig {
 
-  @Value("${FRONTEND_ORIGIN}")
-  private String frontendOrigin;
+  @Value("${frontend.origin:http://localhost:5173}")
+  private String frontendOrigins;
 
   @Bean
   public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
+        String[] allowedOrigins = Arrays.stream(frontendOrigins.split(","))
+          .map(String::trim)
+          .filter(origin -> !origin.isEmpty())
+          .toArray(String[]::new);
+
         registry.addMapping("/**")
-          .allowedOrigins(frontendOrigin)
-          .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
-          .allowedHeaders("*");
+          .allowedOriginPatterns(allowedOrigins)
+          .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+          .allowedHeaders("*")
+          .allowCredentials(true)
+          .maxAge(3600);
       }
     };
   }

--- a/backend/src/main/java/Group3/controller/MealController.java
+++ b/backend/src/main/java/Group3/controller/MealController.java
@@ -69,15 +69,20 @@ public class MealController {
             try {
                 return Long.parseLong(authUserId);
             } catch (NumberFormatException e) {
-                return null;
+                return 1L;
             }
         }
 
         // fallback to the existing dev/test header
         String header = request.getHeader("X-User-Id");
         if (header == null || header.isBlank())
-            return null;
-        return Long.parseLong(header);
+            return 1L;
+
+        try {
+            return Long.parseLong(header);
+        } catch (NumberFormatException e) {
+            return 1L;
+        }
     }
 
     // Temp until OAuth is integrated:

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -22,4 +22,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+server.port=${PORT:8080}
+frontend.origin=${FRONTEND_ORIGIN:http://localhost:5173}
+
 management.endpoints.web.exposure.include=health

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,6 +17,11 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.hikari.maximum-pool-size=${DB_MAX_POOL_SIZE:2}
+spring.datasource.hikari.minimum-idle=${DB_MIN_IDLE:0}
+spring.datasource.hikari.idle-timeout=10000
+spring.datasource.hikari.connection-timeout=20000
+spring.datasource.hikari.max-lifetime=300000
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/frontend/src/pages/MealBuilder.jsx
+++ b/frontend/src/pages/MealBuilder.jsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../supaBaseClient'
 
-const API_BASE = import.meta.env.VITE_API_BASE
+const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '')
+
+const getMealRequestHeaders = (userId) => ({
+  'Content-Type': 'application/json',
+  'X-User-Id': String(userId),
+})
 
 export default function MealBuilder() {
   const [user, setUser] = useState(null)
@@ -120,7 +125,7 @@ export default function MealBuilder() {
       // Create meal record
       const mealResponse = await fetch(`${API_BASE}/meals`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getMealRequestHeaders(userId),
         body: JSON.stringify({
           usersId: userId,
           name: mealName,

--- a/frontend/src/pages/ViewMeals.jsx
+++ b/frontend/src/pages/ViewMeals.jsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../supaBaseClient'
 
-const API_BASE = import.meta.env.VITE_API_BASE
+const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '')
+
+const getMealRequestHeaders = (userId) => ({
+  'Content-Type': 'application/json',
+  'X-User-Id': String(userId),
+})
 
 export default function ViewMeals() {
   const [meals, setMeals] = useState([])
@@ -25,7 +30,11 @@ export default function ViewMeals() {
   const fetchMeals = async (id) => {
     setLoading(true)
     try {
-      const response = await fetch(`${API_BASE}/meals`)
+      const response = await fetch(`${API_BASE}/meals`, {
+        headers: {
+          'X-User-Id': String(id),
+        },
+      })
       if (!response.ok) throw new Error('Failed to fetch meals')
       const allMeals = await response.json()
       
@@ -72,7 +81,7 @@ export default function ViewMeals() {
     try {
       const response = await fetch(`${API_BASE}/meals/${mealId}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getMealRequestHeaders(userId),
         body: JSON.stringify({
           name: editName,
           mealType: editType,

--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,7 @@ services:
     rootDir: backend
     plan: free
     dockerfilePath: Dockerfile
+    healthCheckPath: /health
     autoDeploy: true
     envVars:
       - key: SPRING_DATASOURCE_URL


### PR DESCRIPTION
# Debug Database 
Closes #41

---

## What (The Change)

- Updated backend CORS and origin handling in [backend/src/main/java/Group3/config/CorsConfig.java](backend/src/main/java/Group3/config/CorsConfig.java) to support Render frontend origin, preflight requests, `PATCH`, and credentials.
- Added Render/runtime config in [backend/src/main/resources/application.properties](backend/src/main/resources/application.properties) for `server.port`, frontend origin binding, and safer Hikari pool limits for Supabase pooler usage.
- Added Render health check path in [render.yaml](render.yaml) so backend health is validated at `/health`.
- Updated meal API calls in [frontend/src/pages/MealBuilder.jsx](frontend/src/pages/MealBuilder.jsx) and [frontend/src/pages/ViewMeals.jsx](frontend/src/pages/ViewMeals.jsx) to normalize `VITE_API_BASE` and include `X-User-Id` on meal-protected requests.
- Added root API response endpoint in [backend/src/main/java/Group3/HealthController.java](backend/src/main/java/Group3/HealthController.java) to avoid Whitelabel `404` when visiting backend base URL.
- Added temporary fallback logic for missing/invalid meal user header in [backend/src/main/java/Group3/controller/MealController.java](backend/src/main/java/Group3/controller/MealController.java) to reduce `401` failures during transition.

---

## How (The Implementation)

- CORS now uses configurable origin patterns from env (`FRONTEND_ORIGIN` via `frontend.origin` property), enabling production and local origins without hardcoding.
- Backend now binds to Render’s dynamic port with `server.port=${PORT:8080}` and includes Hikari tuning (`maximum-pool-size`, `minimum-idle`, timeout/lifetime) to prevent Supabase session exhaustion.
- Frontend request builders send `X-User-Id` for `/meals` operations, matching backend expectations in `getCurrentUsersId()`.
- Health flow was aligned for platform checks:
  - Render service health path set to `/health`
  - `GET /` added for human-friendly API base response
- Supabase connection guidance aligned to transaction pooler (`:6543`) with JDBC URL + separate username/password env vars.

---

## Why (The Rationale)

- Production failures were caused by infrastructure/runtime mismatches, not only frontend code:
  - DB session limit exhaustion (`MaxClientInSessionMode`)
  - health check/readiness mismatch
  - missing user header on meal endpoints
- These changes restore API availability and reduce intermittent startup/request failures on Render free tier constraints.
- Trade-off: `MealController` fallback to user `1` is a temporary compatibility measure; proper auth propagation should replace this once OAuth/user sync is fully wired.

---

## Screenshots / Evidence (if applicable)

<img width="1728" height="1117" alt="Screenshot 2026-03-14 at 3 12 43 PM" src="https://github.com/user-attachments/assets/0d33a47f-0c25-43ac-936c-7272177ac772" />
<img width="1728" height="1117" alt="Screenshot 2026-03-14 at 3 12 31 PM" src="https://github.com/user-attachments/assets/05831850-b01c-413b-8a12-9295a13ba0b7" />
<img width="1728" height="1117" alt="Screenshot 2026-03-14 at 3 12 20 PM" src="https://github.com/user-attachments/assets/df8dcec3-d545-4a77-9a07-5d75ff904d27" />
<img width="1728" height="1117" alt="Screenshot 2026-03-14 at 3 12 11 PM" src="https://github.com/user-attachments/assets/1d266d0e-ae8d-44de-93b1-f83ccb8d95eb" />
